### PR TITLE
Allow anonymous functions to be passed to bind() and singleton().

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -21,7 +21,7 @@ abstract class ServiceProvider
     /**
      * @param string $abstract
      * @param \Closure|string|null $concrete
-     * 
+     *
      * @return void
      */
     protected function bind(string $abstract, $concrete = null): void
@@ -32,7 +32,7 @@ abstract class ServiceProvider
     /**
      * @param string $abstract
      * @param \Closure|string|null $concrete
-     * 
+     *
      * @return void
      */
     protected function singleton(string $abstract, $concrete = null): void

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -18,12 +18,24 @@ abstract class ServiceProvider
 
     abstract public function register(): void;
 
-    protected function bind(string $abstract, string $concrete = null): void
+    /**
+     * @param string $abstract
+     * @param \Closure|string|null $concrete
+     * 
+     * @return void
+     */
+    protected function bind(string $abstract, $concrete = null): void
     {
         $this->container->bind($abstract, $concrete);
     }
 
-    protected function singleton(string $abstract, string $concrete = null): void
+    /**
+     * @param string $abstract
+     * @param \Closure|string|null $concrete
+     * 
+     * @return void
+     */
+    protected function singleton(string $abstract, $concrete = null): void
     {
         $this->container->singleton($abstract, $concrete);
     }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace P7v\IlluminateContainerSlim;
 
+use Closure;
 use Illuminate\Container\Container;
 
 abstract class ServiceProvider
@@ -20,9 +21,7 @@ abstract class ServiceProvider
 
     /**
      * @param string $abstract
-     * @param \Closure|string|null $concrete
-     *
-     * @return void
+     * @param Closure|string|null $concrete
      */
     protected function bind(string $abstract, $concrete = null): void
     {
@@ -31,9 +30,7 @@ abstract class ServiceProvider
 
     /**
      * @param string $abstract
-     * @param \Closure|string|null $concrete
-     *
-     * @return void
+     * @param Closure|string|null $concrete
      */
     protected function singleton(string $abstract, $concrete = null): void
     {


### PR DESCRIPTION
Forcing the `$concrete` param to a `string` breaks closures. This change will mimic the actual `bind()` & `singleton()` from `Illuminate\Container\Container`.